### PR TITLE
Add Ethereum support to stablecoin and gateway contract documentation

### DIFF
--- a/resources/gateway-contract-addresses.mdx
+++ b/resources/gateway-contract-addresses.mdx
@@ -13,15 +13,15 @@ Paycrest Gateway contracts are deployed across multiple EVM-compatible networks 
 
 | Network | Chain ID | Gateway Address | Status | Notes |
 |---------|----------|-----------------|--------|-------|
+| **Ethereum** | 1 | `0x8d2C0D398832b814e3814802FF2dC8b8eF4381e5` | ✅ Live | Fully supported |
 | **Base** | 8453 | `0x30F6A8457F8E42371E204a9c103f2Bd42341dD0F` | ✅ Live | Fully supported |
 | **Polygon** | 137 | `0xfB411Cc6385Af50A562aFCb441864E9d541CDA67` | ✅ Live | Fully supported |
 | **BNB Smart Chain** | 56 | `0x1FA0EE7F9410F6fa49B7AD5Da72Cf01647090028` | ✅ Live | Fully supported |
 | **Arbitrum One** | 42161 | `0xE8bc3B607CfE68F47000E3d200310D49041148Fc` | ✅ Live | Fully supported |
 | **Lisk** | 1135 | `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a` | ✅ Live | Fully supported |
 | **Celo** | 42220 | `0xF418217E3f81092eF44b81C5C8336e6A6fDB0E4b` | ✅ Live | Fully supported |
-| **Tron** | 728126428 | `THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU` | ✅ Live | Fully supported |
+| **Tron** | 728126428 | `THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU` | 🚧 Coming Soon| Deployed, aggregator support pending |
 | **Asset Chain** | 42420 | `0xff0E00E0110C1FBb5315D276243497b66D3a4d8a` | 🚧 Coming Soon | Deployed, aggregator support pending |
-| **Ethereum** | 1 | `0x16c9C78Dbb224889E3e2ADef991C8c4438ea797B` | 🚧 Coming Soon | Deployed, aggregator support pending |
 | **Optimism** | 10 | `0xD293fCd3dBc025603911853d893A4724CF9f70a0` | 🚧 Coming Soon | Deployed, aggregator support pending |
 | **Scroll** | 534352 | `0x663C5BfE7d44bA946C2dd4b2D1Cf9580319F9338` | 🚧 Coming Soon | Deployed, aggregator support pending |
 
@@ -43,7 +43,7 @@ All Gateway contracts are verified on their respective network block explorers:
 - **Celo**: [Celo Explorer](https://explorer.celo.org/address/0xF418217E3f81092eF44b81C5C8336e6A6fDB0E4b)
 - **Tron**: [Tronscan](https://tronscan.org/#/address/THyFP5ST9YyLZn6EzjKjFhZti6aKPgEXNU)
 - **Asset Chain**: [Asset Chain Explorer](https://explorer.assetchain.org/address/0xff0E00E0110C1FBb5315D276243497b66D3a4d8a)
-- **Ethereum**: [Etherscan](https://etherscan.io/address/0x16c9C78Dbb224889E3e2ADef991C8c4438ea797B)
+- **Ethereum**: [Etherscan](https://etherscan.io/address/0x8d2C0D398832b814e3814802FF2dC8b8eF4381e5)
 - **Optimism**: [Optimistic Etherscan](https://optimistic.etherscan.io/address/0xD293fCd3dBc025603911853d893A4724CF9f70a0)
 - **Scroll**: [Scrollscan](https://scrollscan.com/address/0x663C5BfE7d44bA946C2dd4b2D1Cf9580319F9338)
 

--- a/resources/supported-stablecoins.mdx
+++ b/resources/supported-stablecoins.mdx
@@ -9,36 +9,39 @@ Paycrest supports multiple stablecoins across various blockchain networks. Each 
 
 | Stablecoin | Networks | Base Currency | Features |
 |------------|----------|--------------|----------|
-| **USDT** | Arbitrum One, Celo, Lisk, BNB Smart Chain, Polygon, Tron | USD | Most widely supported, high liquidity |
-| **USDC** | Base, Arbitrum One, Celo, BNB Smart Chain, Polygon | USD | Regulated, high security standards |
+| **USDT** | Ethereum, Arbitrum One, Celo, Lisk, BNB Smart Chain, Polygon, Tron | USD | Most widely supported, high liquidity |
+| **USDC** | Ethereum, Base, Arbitrum One, Celo, BNB Smart Chain, Polygon | USD | Regulated, high security standards |
 | **CUSD** | Celo | USD | Mobile-first, carbon-negative |
-| **CNGN** | Base, BNB Smart Chain, Polygon | NGN | Stablecoin pegged to Nigerian Naira |
+| **CNGN** | Ethereum, Base, BNB Smart Chain, Polygon | NGN | Stablecoin pegged to Nigerian Naira |
 
 ## Stablecoin Support Matrix
 
-| Stablecoin | Base | Arbitrum One | Celo | Lisk | BNB Smart Chain | Polygon | Tron |
-|------------|------|--------------|------|------|-----------------|---------|------|
-| **USDT** | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **USDC** | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| **CUSD** | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **CNGN** | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| Stablecoin | Ethereum | Base | Arbitrum One | Celo | Lisk | BNB Smart Chain | Polygon | Tron |
+|------------|----------|------|--------------|------|------|-----------------|---------|------|
+| **USDT** | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **USDC** | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| **CUSD** | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **CNGN** | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
 
 ## Stablecoin Contract Addresses
 
 | Stablecoin | Network | Contract Address |
 |------------|---------|------------------|
+| USDT | Ethereum | `0xdAC17F958D2ee523a2206206994597C13D831ec7` |
 | USDT | Arbitrum One | `0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9` |
 | USDT | Celo | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` |
 | USDT | Lisk | `0x05D032ac25d322df992303dCa074EE7392C117b9` |
 | USDT | BNB Smart Chain | `0x55d398326f99059fF775485246999027B3197955` |
 | USDT | Polygon | `0xc2132D05D31c914a87C6611C10748AEb04B58e8F` |
 | USDT | Tron | `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` |
+| USDC | Ethereum | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
 | USDC | Base | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | USDC | Arbitrum One | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
 | USDC | Celo | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` |
 | USDC | BNB Smart Chain | `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d` |
 | USDC | Polygon | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
 | CUSD | Celo | `0x765DE816845861e75A25fCA122bb6898B8B1282a` |
+| CNGN | Ethereum | `0x17CDB2a01e7a34CbB3DD4b83260B05d0274C8dab` |
 | CNGN | Polygon | `0x52828daa48C1a9A06F37500882b42daf0bE04C3B` |
 | CNGN | Base | `0x46C85152bFe9f96829aA94755D9f915F9B10EF5F` |
 | CNGN | BNB Smart Chain | `0xa8AEA66B361a8d53e8865c62D142167Af28Af058` |


### PR DESCRIPTION
Update documentation to include Ethereum as a supported network for stablecoins and gateway contracts, reflecting the current status and contract addresses.