### PR TITLE
docs: add sender webhook delivery logs & retry API

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -448,6 +448,14 @@ Webhook signatures use HMAC-SHA256 over the **exact raw request body**. Do not r
 }
 ```
 
+### Delivery logs & retry
+
+Every webhook send is recorded as a **delivery**. Failed deliveries — transport errors **and** non-2xx responses — are retried automatically with exponential backoff for a 24-hour window, then marked `expired`. You can audit and replay deliveries yourself:
+
+- [List Webhook Deliveries](/api-reference/sender/list-webhook-deliveries) — newest first, filter by `status`, `event`, `event_id`, `order_id`, or date range.
+- [Get Webhook Delivery](/api-reference/sender/get-webhook-delivery-by-id) — full record including request payload and response body.
+- [Retry Webhook Delivery](/api-reference/sender/retry-webhook-delivery) — replay a delivery (`?sync=true` for an inline result, otherwise queued).
+
 <Note>
   For detailed webhook implementation guide including signature verification, retry logic, and best practices, see the [Sender API Integration Guide](/implementation-guides/sender-api-integration#webhooks).
 </Note>

--- a/api-reference/sender/get-webhook-delivery-by-id.mdx
+++ b/api-reference/sender/get-webhook-delivery-by-id.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Webhook Delivery"
+openapi: "openapi-v2.yaml GET /sender/webhooks/{id}"
+---

--- a/api-reference/sender/list-webhook-deliveries.mdx
+++ b/api-reference/sender/list-webhook-deliveries.mdx
@@ -1,0 +1,4 @@
+---
+title: "List Webhook Deliveries"
+openapi: "openapi-v2.yaml GET /sender/webhooks"
+---

--- a/api-reference/sender/retry-webhook-delivery.mdx
+++ b/api-reference/sender/retry-webhook-delivery.mdx
@@ -1,0 +1,4 @@
+---
+title: "Retry Webhook Delivery"
+openapi: "openapi-v2.yaml POST /sender/webhooks/{id}/retry"
+---

--- a/concepts/transaction-lifecycle.mdx
+++ b/concepts/transaction-lifecycle.mdx
@@ -123,7 +123,7 @@ The complete set of order status values:
 
 ## Webhook Events
 
-Paycrest sends webhooks to your configured endpoint as an order progresses. The event name format is `payment_order.<status>`.
+Paycrest sends webhooks to your configured endpoint as an order progresses. The event name format is `payment_order.<status>`. Failed deliveries are retried automatically with exponential backoff, and every delivery is queryable and replayable via the [sender webhook endpoints](/implementation-guides/sender-api-integration#webhook-delivery-logs--retry).
 
 | Event | Triggered When |
 |-------|---------------|

--- a/docs.json
+++ b/docs.json
@@ -82,7 +82,10 @@
                   "api-reference/sender/initiate-payment-order-v2",
                   "api-reference/sender/list-payment-orders-v2",
                   "api-reference/sender/get-payment-order-by-id-v2",
-                  "api-reference/sender/get-sender-stats"
+                  "api-reference/sender/get-sender-stats",
+                  "api-reference/sender/list-webhook-deliveries",
+                  "api-reference/sender/get-webhook-delivery-by-id",
+                  "api-reference/sender/retry-webhook-delivery"
                 ]
               },
               {

--- a/implementation-guides/sender-api-integration.mdx
+++ b/implementation-guides/sender-api-integration.mdx
@@ -461,6 +461,53 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
   </Tab>
 </Tabs>
 
+### Webhook delivery logs & retry
+
+Every webhook we send is recorded as a **delivery** you can inspect and replay — so a briefly-down endpoint no longer means a lost event.
+
+**Automatic retries.** A delivery that fails — either a transport error **or a non-2xx response** — is retried automatically with exponential backoff. Retries continue for a cumulative **24-hour window**, after which the delivery is marked `expired` and we email your sender account once. Return a `2xx` status as soon as you've accepted the event to stop retries.
+
+Each delivery has a `status`:
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Queued or awaiting its next retry |
+| `success` | Your endpoint returned a 2xx |
+| `failed` | Transport error or non-2xx; scheduled for retry |
+| `expired` | Gave up after the 24h retry window |
+
+The `trigger` field records what produced an attempt: `automatic` (first send), `cron_retry` (automatic backoff retry), or `manual_sync` / `manual_async` (a retry you initiated).
+
+**Inspect deliveries.** List your deliveries (newest first), filtered by `status`, `event`, `event_id`, `order_id`, or a `from`/`to` date range:
+
+```bash
+curl "https://api.paycrest.io/v2/sender/webhooks?status=failed" \
+  -H "API-Key: YOUR_API_KEY"
+```
+
+Fetch a single delivery to see the frozen request payload and the captured response body (truncated to 4KB):
+
+```bash
+curl "https://api.paycrest.io/v2/sender/webhooks/DELIVERY_ID" \
+  -H "API-Key: YOUR_API_KEY"
+```
+
+**Replay a delivery.** Retry replays the original frozen payload. Use `?sync=true` to replay immediately and get the HTTP result inline:
+
+```bash
+curl -X POST "https://api.paycrest.io/v2/sender/webhooks/DELIVERY_ID/retry?sync=true" \
+  -H "API-Key: YOUR_API_KEY"
+```
+
+Omit `sync` to queue a new delivery for the retry worker instead — the response is `202` with the new delivery's `id`:
+
+```bash
+curl -X POST "https://api.paycrest.io/v2/sender/webhooks/DELIVERY_ID/retry" \
+  -H "API-Key: YOUR_API_KEY"
+```
+
+All three endpoints are scoped to the authenticated sender; another sender's delivery returns `404`. See [List Webhook Deliveries](/api-reference/sender/list-webhook-deliveries), [Get Webhook Delivery](/api-reference/sender/get-webhook-delivery-by-id), and [Retry Webhook Delivery](/api-reference/sender/retry-webhook-delivery).
+
 ### Polling
 
 ```javascript

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -894,6 +894,122 @@ components:
               type: string
               format: date-time
 
+    WebhookDelivery:
+      type: object
+      description: |
+        A single outbound webhook delivery attempt. Returned in list responses
+        (the large `requestPayload` and `responseBody` fields are omitted from list
+        items — fetch a single delivery to see them).
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique ID of this delivery record.
+        event:
+          type: string
+          enum: [payment_order.deposited, payment_order.pending, payment_order.validated, payment_order.settling, payment_order.settled, payment_order.refunding, payment_order.refunded, payment_order.expired]
+          description: The webhook event that was delivered.
+        eventId:
+          type: string
+          description: Identifier of the underlying event (matches the `event_id` filter).
+        orderId:
+          type: string
+          format: uuid
+          description: The payment order this delivery relates to, if any.
+        status:
+          type: string
+          enum: [pending, success, failed, expired]
+          description: |
+            Delivery status. `pending` — queued or awaiting retry; `success` — the
+            endpoint returned a 2xx; `failed` — a transport error or non-2xx response,
+            scheduled for retry; `expired` — gave up after the 24h retry window.
+        trigger:
+          type: string
+          enum: [automatic, cron_retry, manual_sync, manual_async]
+          description: |
+            What produced this attempt. `automatic` — first send on the event;
+            `cron_retry` — automatic backoff retry; `manual_sync`/`manual_async` —
+            a sender-initiated retry via the retry endpoint.
+        httpStatusCode:
+          type: integer
+          description: HTTP status code returned by your endpoint (0 if no response was received).
+          example: 200
+        attemptNumber:
+          type: integer
+          description: 1-based attempt counter for this delivery.
+          example: 1
+        destinationUrl:
+          type: string
+          format: uri
+          description: The webhook URL the request was sent to.
+        signature:
+          type: string
+          description: The `X-Paycrest-Signature` (HMAC-SHA256 hex) sent with the request.
+        errorMessage:
+          type: string
+          description: Transport or HTTP error message, if the attempt failed.
+        durationMs:
+          type: integer
+          description: Round-trip duration of the attempt, in milliseconds.
+        nextRetryTime:
+          type: string
+          format: date-time
+          description: When the next automatic retry is scheduled (null once delivered or expired).
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    WebhookDeliveryDetail:
+      description: A single webhook delivery including the frozen request payload and captured response body.
+      allOf:
+        - $ref: '#/components/schemas/WebhookDelivery'
+        - type: object
+          properties:
+            requestPayload:
+              type: object
+              description: The exact JSON body that was (or will be) sent, frozen at first attempt.
+            responseBody:
+              type: string
+              description: Response body returned by your endpoint, truncated to 4KB.
+
+    WebhookDeliveryList:
+      type: object
+      properties:
+        total:
+          type: integer
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        deliveries:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebhookDelivery'
+
+    WebhookRetryResult:
+      type: object
+      description: |
+        Result of a synchronous retry (`?sync=true`). Reports the HTTP outcome of
+        replaying the original payload inline.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: ID of the delivery record created for this retry.
+        status:
+          type: string
+          enum: [success, failed]
+        httpStatusCode:
+          type: integer
+          example: 200
+        durationMs:
+          type: integer
+        errorMessage:
+          type: string
+
 
 
 servers:
@@ -1688,6 +1804,185 @@ paths:
           description: Unauthorized
         '404':
           description: Order not found
+
+  /sender/webhooks:
+    get:
+      tags:
+        - Sender
+      summary: List webhook deliveries
+      description: |
+        Returns the authenticated sender's webhook delivery log, newest first.
+        Use this to audit which events were delivered and to find failed or expired
+        deliveries to replay. List items omit the large `requestPayload` and
+        `responseBody` fields — fetch a single delivery to see them.
+      security:
+        - ApiKeyAuth: []
+      servers:
+        - url: https://api.paycrest.io/v2
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [pending, success, failed, expired]
+          description: Filter by delivery status.
+        - in: query
+          name: event
+          schema:
+            type: string
+          description: Filter by event name, e.g. `payment_order.settled`.
+        - in: query
+          name: event_id
+          schema:
+            type: string
+          description: Filter by the underlying event identifier.
+        - in: query
+          name: order_id
+          schema:
+            type: string
+            format: uuid
+          description: Filter to deliveries for a single payment order.
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+          description: Only deliveries created at or after this timestamp.
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+          description: Only deliveries created at or before this timestamp.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of webhook deliveries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    $ref: '#/components/schemas/WebhookDeliveryList'
+        '401':
+          description: Unauthorized
+
+  /sender/webhooks/{id}:
+    get:
+      tags:
+        - Sender
+      summary: Get a webhook delivery by ID
+      description: |
+        Returns a single webhook delivery, including the frozen `requestPayload`
+        and the captured `responseBody`. Returns `404` if the delivery belongs to
+        another sender.
+      security:
+        - ApiKeyAuth: []
+      servers:
+        - url: https://api.paycrest.io/v2
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Webhook delivery
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    $ref: '#/components/schemas/WebhookDeliveryDetail'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Delivery not found
+
+  /sender/webhooks/{id}/retry:
+    post:
+      tags:
+        - Sender
+      summary: Retry a webhook delivery
+      description: |
+        Replays a webhook delivery using its original frozen payload.
+
+        - **Synchronous** (`?sync=true`): the payload is re-sent immediately and the
+          HTTP result is returned inline (`200`).
+        - **Asynchronous** (default): a new `pending` delivery is queued for the retry
+          worker and the new delivery ID is returned (`202`).
+
+        Returns `404` if the delivery belongs to another sender.
+      security:
+        - ApiKeyAuth: []
+      servers:
+        - url: https://api.paycrest.io/v2
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: query
+          name: sync
+          schema:
+            type: boolean
+            default: false
+          description: When `true`, replay immediately and return the HTTP result inline.
+      responses:
+        '200':
+          description: Synchronous retry result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    $ref: '#/components/schemas/WebhookRetryResult'
+        '202':
+          description: Asynchronous retry queued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Webhook retry queued
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        description: ID of the newly queued delivery.
+        '401':
+          description: Unauthorized
+        '404':
+          description: Delivery not found
 
   # ─── V2 Provider Endpoints ────────────────────────────────────────────────────
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -9,6 +9,21 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ## Q2 2026
 
+### Webhook delivery logs & retry API (June 2026)
+
+Senders can now audit and replay webhook deliveries instead of re-triggering the order flow when an endpoint is briefly down.
+
+**New endpoints:**
+- `GET /v2/sender/webhooks` — list deliveries (newest first); filters: `status`, `event`, `event_id`, `order_id`, `from`, `to`.
+- `GET /v2/sender/webhooks/:id` — full delivery record including request payload and response body.
+- `POST /v2/sender/webhooks/:id/retry` — replay a delivery. `?sync=true` replays immediately and returns the HTTP result inline; otherwise a new delivery is queued and the API returns `202` with its ID.
+
+**Behavior change:** non-2xx responses now count as failed deliveries and are retried (previously only transport errors were). Retries use exponential backoff and expire after a cumulative 24-hour window, after which the sender is emailed once.
+
+See [Webhook delivery logs & retry](/implementation-guides/sender-api-integration#webhook-delivery-logs--retry) and [List Webhook Deliveries](/api-reference/sender/list-webhook-deliveries).
+
+---
+
 ### Verify-account mobile money normalization (June 2026)
 
 **`POST /v1/verify-account`** and **`POST /v2/verify-account`** now normalize **mobile_money** `accountIdentifier` values before provider verification (country dial code, strip `+` and leading `0`). Supported fiat dial codes: KES `254`, UGX `256`, TZS `255`, GHS `233`, MWK `265`.

--- a/resources/troubleshooting.mdx
+++ b/resources/troubleshooting.mdx
@@ -77,6 +77,15 @@ This guide helps you resolve common issues when integrating with the Paycrest AP
       <li>Ensure your webhook endpoint can handle POST requests</li>
       <li>Verify webhook signature for security</li>
     </ul>
+
+    <h4>Inspect and replay deliveries</h4>
+    <p>You don't need to re-trigger the order flow to recover a missed event. Every send is logged as a delivery you can audit and replay:</p>
+    <ul>
+      <li>List failed deliveries: <code>GET /v2/sender/webhooks?status=failed</code></li>
+      <li>Read the captured response body and error: <code>GET /v2/sender/webhooks/:id</code></li>
+      <li>Replay the original payload: <code>POST /v2/sender/webhooks/:id/retry</code> (<code>?sync=true</code> returns the HTTP result inline; otherwise it's queued)</li>
+    </ul>
+    <p>Failed deliveries (transport errors and non-2xx responses) are also retried automatically with exponential backoff for 24 hours before being marked <code>expired</code>. See the <a href="/implementation-guides/sender-api-integration#webhook-delivery-logs--retry">webhook delivery logs &amp; retry guide</a>.</p>
     
     <h4>Webhook Signature Verification</h4>
     


### PR DESCRIPTION
## What & why

Documents [paycrest/aggregator#816](https://github.com/paycrest/aggregator/pull/816), which gives senders first-class **webhook delivery logs** plus a **retry API**. Today a sender whose endpoint is briefly down loses the event with no recourse; the backend change lets them audit and replay deliveries themselves. These docs expose the three new endpoints and document the retry/expiry behavior.

## Scope

- **API reference: v2 only** — the Legacy v1 reference is intentionally left untouched (new features land on the latest version).
- **Full prose update** of the relevant guide, API-reference, troubleshooting, lifecycle, and changelog sections.

## Changes

**API reference (the new endpoints)**
- `openapi-v2.yaml` — added 3 paths under the `Sender` tag:
  - `GET /sender/webhooks` — paginated, newest first; filters `status`, `event`, `event_id`, `order_id`, `from`, `to`.
  - `GET /sender/webhooks/{id}` — full record incl. frozen request payload + captured response body.
  - `POST /sender/webhooks/{id}/retry` — `?sync=true` replays inline (`200`); otherwise queues a delivery and returns `202` with its ID.
  - New schemas: `WebhookDelivery`, `WebhookDeliveryDetail`, `WebhookDeliveryList`, `WebhookRetryResult`.
- New wrapper pages: `api-reference/sender/{list-webhook-deliveries,get-webhook-delivery-by-id,retry-webhook-delivery}.mdx`.
- `docs.json` — added the 3 pages to the v2 Sender nav group.

**Prose**
- `implementation-guides/sender-api-integration.mdx` — new "Webhook delivery logs & retry" section: status/trigger tables, automatic exponential backoff, 24h expiry window + one expiry email, and curl examples (list/detail/sync/async).
- `api-reference/introduction.mdx` — "Delivery logs & retry" paragraph; makes the previously-dangling "retry logic" link real.
- `resources/troubleshooting.mdx` — "Inspect and replay deliveries" under Webhook Issues.
- `concepts/transaction-lifecycle.mdx` — one-line note on retries + replay.
- `resources/changelog.mdx` — new June 2026 entry incl. the **non-2xx-now-retried** behavior change.

## Reviewer notes

- **Field-name accuracy:** response field names/shapes (`durationMs`, `eventId`, `orderId`, `responseBody`, etc.) were modeled from the PR description, **not** verified against the actual serializer in `controllers/sender/webhooks.go` / `types/types.go`. Worth a check against the wire format before publishing.
- Deliberately **out of scope** (per the PR's own notes): per-sender retry rate limiting (deferred follow-up), the dropped internal `WebhookRetryAttempt` table, and v1 reference pages.
- Validated: `openapi-v2.yaml` parses (3 paths + 4 schemas present) and `docs.json` is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)