### PR TITLE
docs(markets): document GET /v2/markets orderbook + provider rate position

### DIFF
--- a/api-reference/general/get-markets.mdx
+++ b/api-reference/general/get-markets.mdx
@@ -1,0 +1,131 @@
+---
+title: 'Get Markets'
+openapi: "openapi-v2.yaml GET /markets"
+---
+
+Returns the live protocol **orderbook** (every funded, available provider quote across corridors × tokens × networks) plus **network-wide aggregate statistics**. Use this endpoint to display live liquidity, rates, and protocol health without requiring authentication.
+
+<Note>
+  **Public endpoint** — no API key or HMAC signature required. CORS is open. Responses are served from a ~10 s Redis cache and are per-IP rate limited.
+</Note>
+
+## Response shape (`data`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `as_of` | string (ISO 8601) | Timestamp when the response was generated |
+| `aggregates` | object | Network-wide aggregate statistics (see below) |
+| `book` | array | Provider quote rows forming the live orderbook |
+
+## Book row fields
+
+Each element of `book` is a single provider quote for one `side` on one `network`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider_id` | string | Provider identifier |
+| `side` | string | `sell` = offramp (crypto → fiat); `buy` = onramp (fiat → crypto) |
+| `token` | string | Token symbol, e.g. `USDT`, `USDC` |
+| `fiat` | string | Fiat currency code, e.g. `NGN`, `KES` |
+| `network` | string | Network identifier, e.g. `base`, `ethereum` |
+| `rate` | string | Provider's effective rate (fiat per crypto for sell; crypto per fiat for buy) |
+| `rate_type` | string | `fixed` or `floating` |
+| `min` | string | Minimum order amount for this corridor |
+| `max` | string | Maximum order amount for this corridor |
+| `balance` | string | Available liquidity: fiat amount for sell rows, token amount for buy rows |
+| `balance_ccy` | string | Currency of `balance` — fiat code for sell, token symbol for buy |
+| `balance_usd` | string | Balance normalised to USD |
+| `settled` | integer | Total settled orders for this provider in this corridor |
+| `success_pct` | string \| null | Success rate as a percentage string (`null` when no settled or refunded history) |
+
+<Note>
+  `balance` is a **shared pool** repeated across a provider's networks for the same fiat (sell) or token (buy). De-duplicate by `provider_id + fiat` (sell) or `provider_id + token` (buy) when summing total depth to avoid double-counting.
+</Note>
+
+**Qualifying offer filters:** `is_available = true`, funded (positive balance), enabled fiat/token, non-testnet network. All book rows are public regardless of a provider's visibility setting—visibility only affects the narrower position benchmark pool on the [Get Market Rate](/api-reference/provider/get-market-rate) endpoint.
+
+## Aggregates fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `settled_volume_usd` | windowed | USD volume of settled orders — `24h`, `7d`, `30d`, `all` (strings) |
+| `settled_txns` | windowed | Count of settled transactions — `24h`, `7d`, `30d`, `all` (integers) |
+| `network_success_pct` | windowed | Network success rate (settled / (settled + refunded)) — `24h`, `7d`, `30d` (strings or null) |
+| `median_delivery_secs` | windowed | Median order delivery time in seconds — `24h`, `7d`, `30d` (integers or null) |
+| `active_providers` | windowed | Distinct providers with ≥1 settled order — `24h`, `7d`, `30d`, `all` (integers) |
+| `active_senders` | windowed | Distinct senders with ≥1 settled order — `24h`, `7d`, `30d`, `all` (integers) |
+| `live_liquidity_usd` | string | Total available USD-denominated liquidity across all book rows |
+| `corridors` | integer | Distinct token/fiat pairs in the current book |
+| `tokens` | integer | Distinct tokens in the current book |
+| `networks` | integer | Distinct networks in the current book |
+
+Windowed success and median fields are `null` for a window when no terminal orders exist in that period.
+
+## Example
+
+```bash
+GET https://api.paycrest.io/v2/markets
+```
+
+```json
+{
+  "status": "success",
+  "message": "OK",
+  "data": {
+    "as_of": "2026-06-08T14:30:00Z",
+    "aggregates": {
+      "settled_volume_usd": { "24h": "48200.00", "7d": "312500.00", "30d": "1420000.00", "all": "9800000.00" },
+      "settled_txns":       { "24h": 118,         "7d": 790,         "30d": 3350,         "all": 43000 },
+      "network_success_pct": { "24h": "98.30", "7d": "97.60", "30d": "97.10" },
+      "median_delivery_secs": { "24h": 175, "7d": 190, "30d": 205 },
+      "active_providers":   { "24h": 42, "7d": 49, "30d": 55, "all": 115 },
+      "active_senders":     { "24h": 1150, "7d": 8200, "30d": 33000, "all": 490000 },
+      "live_liquidity_usd": "2350000.00",
+      "corridors": 11,
+      "tokens": 3,
+      "networks": 4
+    },
+    "book": [
+      {
+        "provider_id": "AbCdEfGh",
+        "side": "sell",
+        "token": "USDT",
+        "fiat": "NGN",
+        "network": "base",
+        "rate": "1605.50",
+        "rate_type": "floating",
+        "min": "500.00",
+        "max": "500000.00",
+        "balance": "12000000.00",
+        "balance_ccy": "NGN",
+        "balance_usd": "7462.69",
+        "settled": 3200,
+        "success_pct": "98.90"
+      },
+      {
+        "provider_id": "IjKlMnOp",
+        "side": "buy",
+        "token": "USDC",
+        "fiat": "KES",
+        "network": "ethereum",
+        "rate": "130.25",
+        "rate_type": "fixed",
+        "min": "100.00",
+        "max": "100000.00",
+        "balance": "9500.00",
+        "balance_ccy": "USDC",
+        "balance_usd": "9500.00",
+        "settled": 850,
+        "success_pct": "97.20"
+      }
+    ]
+  }
+}
+```
+
+## Errors
+
+| HTTP | Cause |
+|------|-------|
+| **429** | Per-IP rate limit exceeded |
+| **500** | Internal error |

--- a/api-reference/general/get-markets.mdx
+++ b/api-reference/general/get-markets.mdx
@@ -6,14 +6,14 @@ openapi: "openapi-v2.yaml GET /markets"
 Returns the live protocol **orderbook** (every funded, available provider quote across corridors × tokens × networks) plus **network-wide aggregate statistics**. Use this endpoint to display live liquidity, rates, and protocol health without requiring authentication.
 
 <Note>
-  **Public endpoint** — no API key or HMAC signature required. CORS is open. Responses are served from a ~10 s Redis cache and are per-IP rate limited.
+  **Public endpoint** — no API key or HMAC signature required. CORS is open. Responses are cached for ~10 s and are per-IP rate limited.
 </Note>
 
 ## Response shape (`data`)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `as_of` | string (ISO 8601) | Timestamp when the response was generated |
+| `asOf` | string (ISO 8601) | Timestamp when the response was generated |
 | `aggregates` | object | Network-wide aggregate statistics (see below) |
 | `book` | array | Provider quote rows forming the live orderbook |
 
@@ -23,23 +23,23 @@ Each element of `book` is a single provider quote for one `side` on one `network
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `provider_id` | string | Provider identifier |
+| `providerId` | string | Provider identifier |
 | `side` | string | `sell` = offramp (crypto → fiat); `buy` = onramp (fiat → crypto) |
 | `token` | string | Token symbol, e.g. `USDT`, `USDC` |
 | `fiat` | string | Fiat currency code, e.g. `NGN`, `KES` |
 | `network` | string | Network identifier, e.g. `base`, `ethereum` |
 | `rate` | string | Provider's effective rate (fiat per crypto for sell; crypto per fiat for buy) |
-| `rate_type` | string | `fixed` or `floating` |
+| `rateType` | string | `fixed` or `floating` |
 | `min` | string | Minimum order amount for this corridor |
 | `max` | string | Maximum order amount for this corridor |
 | `balance` | string | Available liquidity: fiat amount for sell rows, token amount for buy rows |
-| `balance_ccy` | string | Currency of `balance` — fiat code for sell, token symbol for buy |
-| `balance_usd` | string | Balance normalised to USD |
+| `balanceCurrency` | string | Currency of `balance` — fiat code for sell, token symbol for buy |
+| `balanceUsd` | string | Balance normalised to USD |
 | `settled` | integer | Total settled orders for this provider in this corridor |
-| `success_pct` | string \| null | Success rate as a percentage string (`null` when no settled or refunded history) |
+| `successPercent` | string \| null | Success rate as a percentage string (`null` when no settled or refunded history) |
 
 <Note>
-  `balance` is a **shared pool** repeated across a provider's networks for the same fiat (sell) or token (buy). De-duplicate by `provider_id + fiat` (sell) or `provider_id + token` (buy) when summing total depth to avoid double-counting.
+  `balance` is a **shared pool** repeated across a provider's networks for the same fiat (sell) or token (buy). De-duplicate by `providerId + fiat` (sell) or `providerId + token` (buy) when summing total depth to avoid double-counting.
 </Note>
 
 **Qualifying offer filters:** `is_available = true`, funded (positive balance), enabled fiat/token, non-testnet network. All book rows are public regardless of a provider's visibility setting—visibility only affects the narrower position benchmark pool on the [Get Market Rate](/api-reference/provider/get-market-rate) endpoint.
@@ -48,13 +48,13 @@ Each element of `book` is a single provider quote for one `side` on one `network
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `settled_volume_usd` | windowed | USD volume of settled orders — `24h`, `7d`, `30d`, `all` (strings) |
-| `settled_txns` | windowed | Count of settled transactions — `24h`, `7d`, `30d`, `all` (integers) |
-| `network_success_pct` | windowed | Network success rate (settled / (settled + refunded)) — `24h`, `7d`, `30d` (strings or null) |
-| `median_delivery_secs` | windowed | Median order delivery time in seconds — `24h`, `7d`, `30d` (integers or null) |
-| `active_providers` | windowed | Distinct providers with ≥1 settled order — `24h`, `7d`, `30d`, `all` (integers) |
-| `active_senders` | windowed | Distinct senders with ≥1 settled order — `24h`, `7d`, `30d`, `all` (integers) |
-| `live_liquidity_usd` | string | Total available USD-denominated liquidity across all book rows |
+| `settledVolumeUsd` | windowed | USD volume of settled orders — `24h`, `7d`, `30d`, `all` (strings) |
+| `settledTxns` | windowed | Count of settled transactions — `24h`, `7d`, `30d`, `all` (integers) |
+| `networkSuccessPercent` | windowed | Network success rate (settled / (settled + refunded)) — `24h`, `7d`, `30d` (strings or null) |
+| `medianDeliverySecs` | windowed | Median order delivery time in seconds — `24h`, `7d`, `30d` (integers or null) |
+| `activeProviders` | windowed | Distinct providers with ≥1 settled order — `24h`, `7d`, `30d`, `all` (integers) |
+| `activeSenders` | windowed | Distinct senders with ≥1 settled order — `24h`, `7d`, `30d`, `all` (integers) |
+| `liveLiquidityUsd` | string | Total available USD-denominated liquidity across all book rows |
 | `corridors` | integer | Distinct token/fiat pairs in the current book |
 | `tokens` | integer | Distinct tokens in the current book |
 | `networks` | integer | Distinct networks in the current book |
@@ -72,51 +72,51 @@ GET https://api.paycrest.io/v2/markets
   "status": "success",
   "message": "OK",
   "data": {
-    "as_of": "2026-06-08T14:30:00Z",
+    "asOf": "2026-06-08T14:30:00Z",
     "aggregates": {
-      "settled_volume_usd": { "24h": "48200.00", "7d": "312500.00", "30d": "1420000.00", "all": "9800000.00" },
-      "settled_txns":       { "24h": 118,         "7d": 790,         "30d": 3350,         "all": 43000 },
-      "network_success_pct": { "24h": "98.30", "7d": "97.60", "30d": "97.10" },
-      "median_delivery_secs": { "24h": 175, "7d": 190, "30d": 205 },
-      "active_providers":   { "24h": 42, "7d": 49, "30d": 55, "all": 115 },
-      "active_senders":     { "24h": 1150, "7d": 8200, "30d": 33000, "all": 490000 },
-      "live_liquidity_usd": "2350000.00",
+      "settledVolumeUsd": { "24h": "48200.00", "7d": "312500.00", "30d": "1420000.00", "all": "9800000.00" },
+      "settledTxns":       { "24h": 118,         "7d": 790,         "30d": 3350,         "all": 43000 },
+      "networkSuccessPercent": { "24h": "98.30", "7d": "97.60", "30d": "97.10" },
+      "medianDeliverySecs": { "24h": 175, "7d": 190, "30d": 205 },
+      "activeProviders":   { "24h": 42, "7d": 49, "30d": 55, "all": 115 },
+      "activeSenders":     { "24h": 1150, "7d": 8200, "30d": 33000, "all": 490000 },
+      "liveLiquidityUsd": "2350000.00",
       "corridors": 11,
       "tokens": 3,
       "networks": 4
     },
     "book": [
       {
-        "provider_id": "AbCdEfGh",
+        "providerId": "AbCdEfGh",
         "side": "sell",
         "token": "USDT",
         "fiat": "NGN",
         "network": "base",
         "rate": "1605.50",
-        "rate_type": "floating",
+        "rateType": "floating",
         "min": "500.00",
         "max": "500000.00",
         "balance": "12000000.00",
-        "balance_ccy": "NGN",
-        "balance_usd": "7462.69",
+        "balanceCurrency": "NGN",
+        "balanceUsd": "7462.69",
         "settled": 3200,
-        "success_pct": "98.90"
+        "successPercent": "98.90"
       },
       {
-        "provider_id": "IjKlMnOp",
+        "providerId": "IjKlMnOp",
         "side": "buy",
         "token": "USDC",
         "fiat": "KES",
         "network": "ethereum",
         "rate": "130.25",
-        "rate_type": "fixed",
+        "rateType": "fixed",
         "min": "100.00",
         "max": "100000.00",
         "balance": "9500.00",
-        "balance_ccy": "USDC",
-        "balance_usd": "9500.00",
+        "balanceCurrency": "USDC",
+        "balanceUsd": "9500.00",
         "settled": 850,
-        "success_pct": "97.20"
+        "successPercent": "97.20"
       }
     ]
   }

--- a/api-reference/provider/get-market-rate-v1.mdx
+++ b/api-reference/provider/get-market-rate-v1.mdx
@@ -6,3 +6,5 @@ openapi: "openapi-v1.yaml GET /provider/rates/{token}/{fiat}"
 Retrieve the market rate for a token and fiat pair (v1 path; **same response shape** as `GET /v2/provider/rates/{token}/{fiat}`).
 
 The `data` object contains **`buy`** and **`sell`** sides when applicable, each with `marketRate`, `minimumRate`, and `maximumRate` (strings). The older flat fields `marketBuyRate` / `marketSellRate` / `minimumRate` / `maximumRate` at the top level are **no longer** returned.
+
+The optional **`position`** object (`bestPublicRate`, `yourEffectiveRate`, `deltaVsBest`) applies to this v1 path with the same semantics as the v2 route. See [Get Market Rate (v2)](/api-reference/provider/get-market-rate) for full `position` documentation.

--- a/api-reference/provider/get-market-rate.mdx
+++ b/api-reference/provider/get-market-rate.mdx
@@ -9,11 +9,89 @@ Returns **buy** and **sell** market rate **bands** (reference rate plus min/max 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `buy` | object (optional) | Buy-side band: `marketRate`, `minimumRate`, `maximumRate` |
-| `sell` | object (optional) | Sell-side band: `marketRate`, `minimumRate`, `maximumRate` |
+| `buy` | object (optional) | Buy-side band — see fields below |
+| `sell` | object (optional) | Sell-side band — see fields below |
+
+Each side object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `marketRate` | string | Reference market rate for this side (fiat per crypto) |
+| `minimumRate` | string | Minimum allowed rate for this side |
+| `maximumRate` | string | Maximum allowed rate for this side |
+| `position` | object (optional) | Rate benchmark vs. best public peer — see below |
 
 Numeric values are returned as **strings** (decimal). Either side may be omitted depending on corridor configuration.
 
+## `position` object
+
+When qualifying public offers exist for this corridor, each side includes a `position` object so you can see how your effective rate compares to the best public peer:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bestPublicRate` | string | Best rate among enabled non-testnet public peers (highest for sell; lowest for buy) |
+| `yourEffectiveRate` | string | Your own effective rate for this corridor and side |
+| `deltaVsBest` | string | `yourEffectiveRate − bestPublicRate` |
+
+**Interpreting `deltaVsBest`:**
+- **Sell** (offramp): a **positive** delta means your rate is higher than the best peer — you are more competitive.
+- **Buy** (onramp): a **negative** delta means your rate is lower than the best peer — you are more competitive.
+
+`position` is **omitted** when:
+- No qualifying public offers exist for the corridor, or
+- You have no effective rate configured for this corridor.
+
+The reference fields `marketRate`, `minimumRate`, and `maximumRate` are **unchanged** — `position` is purely additive (backward compatible).
+
+The benchmark pool uses all enabled, non-testnet networks; it is not filtered by the `{token}/{fiat}` path parameters' network.
+
+## Example
+
+```json
+{
+  "status": "success",
+  "message": "Rate fetched successfully",
+  "data": {
+    "sell": {
+      "marketRate": "1605.00",
+      "minimumRate": "1580.00",
+      "maximumRate": "1630.00",
+      "position": {
+        "bestPublicRate": "1608.00",
+        "yourEffectiveRate": "1605.00",
+        "deltaVsBest": "-3.00"
+      }
+    },
+    "buy": {
+      "marketRate": "1598.00",
+      "minimumRate": "1575.00",
+      "maximumRate": "1620.00",
+      "position": {
+        "bestPublicRate": "1595.00",
+        "yourEffectiveRate": "1598.00",
+        "deltaVsBest": "3.00"
+      }
+    }
+  }
+}
+```
+
+Example when `position` is omitted (no public benchmark available):
+
+```json
+{
+  "status": "success",
+  "message": "Rate fetched successfully",
+  "data": {
+    "sell": {
+      "marketRate": "1605.00",
+      "minimumRate": "1580.00",
+      "maximumRate": "1630.00"
+    }
+  }
+}
+```
+
 <Note>
-  **`GET /v1/provider/rates/{token}/{fiat}`** uses the same response shape as this v2 route.
+  **`GET /v1/provider/rates/{token}/{fiat}`** uses the same response shape as this v2 route, including the `position` field. See [Get Market Rate (v1)](/api-reference/provider/get-market-rate-v1).
 </Note>

--- a/docs.json
+++ b/docs.json
@@ -105,6 +105,7 @@
                   "api-reference/general/list-supported-institutions",
                   "api-reference/general/list-supported-tokens",
                   "api-reference/general/get-token-rate",
+                  "api-reference/general/get-markets",
                   "api-reference/general/get-aggregator-public-key",
                   "api-reference/general/verify-account",
                   "api-reference/sender/get-lock-payment-order-status",

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -290,6 +290,22 @@ components:
       properties:
         reason:
           type: string
+    MarketPosition:
+      type: object
+      description: |
+        Provider's rate standing versus the best public peer in the same corridor.
+        Omitted when no qualifying public offers exist or the provider has no effective rate for the corridor (backward compatible).
+      properties:
+        bestPublicRate:
+          type: string
+          description: Best rate among enabled non-testnet public peers for this side (highest effective sell rate; lowest effective buy rate).
+        yourEffectiveRate:
+          type: string
+          description: The provider's own effective rate for this corridor and side.
+        deltaVsBest:
+          type: string
+          description: |
+            `yourEffectiveRate − bestPublicRate`. For **sell** a positive delta means you offer a higher rate than the best peer (more competitive). For **buy** a negative delta means you offer a lower rate than the best peer (more competitive).
     MarketRateSide:
       type: object
       description: Tolerance band for one side (buy or sell) of the market rate.
@@ -300,6 +316,10 @@ components:
           type: string
         maximumRate:
           type: string
+        position:
+          allOf:
+            - $ref: '#/components/schemas/MarketPosition'
+          description: Rate benchmark vs. best public peer. Omitted when no public benchmark exists (backward compatible).
     MarketRateResponse:
       type: object
       description: Market rate bounds split by side (same shape as `GET /v2/provider/rates/{token}/{fiat}`).

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -351,7 +351,7 @@ components:
         One provider quote row in the public markets orderbook (one row per provider × side × token × fiat × network).
         All funded, available providers appear regardless of visibility setting—only `is_available`, funded, enabled, and non-testnet gating applies.
       properties:
-        provider_id:
+        providerId:
           type: string
           description: Provider identifier.
         side:
@@ -370,7 +370,7 @@ components:
         rate:
           type: string
           description: Provider's effective exchange rate for this row (fiat per crypto for sell; crypto per fiat for buy).
-        rate_type:
+        rateType:
           type: string
           enum: [fixed, floating]
           description: Whether the rate is fixed or floating.
@@ -383,20 +383,20 @@ components:
         balance:
           type: string
           description: |
-            Provider's available liquidity for this side. For **sell** this is in fiat (`balance_ccy` = fiat code);
-            for **buy** this is in token (`balance_ccy` = token symbol).
+            Provider's available liquidity for this side. For **sell** this is in fiat (`balanceCurrency` = fiat code);
+            for **buy** this is in token (`balanceCurrency` = token symbol).
             The balance is the shared pool repeated across a provider's networks for the same fiat/token—
-            de-duplicate by `provider_id + fiat` (sell) or `provider_id + token` (buy) when summing depth.
-        balance_ccy:
+            de-duplicate by `providerId + fiat` (sell) or `providerId + token` (buy) when summing depth.
+        balanceCurrency:
           type: string
           description: Currency of `balance` — fiat code for sell rows, token symbol for buy rows.
-        balance_usd:
+        balanceUsd:
           type: string
           description: Balance normalised to USD.
         settled:
           type: integer
           description: Total number of settled orders for this provider in this corridor.
-        success_pct:
+        successPercent:
           type: string
           nullable: true
           description: Provider's success rate (settled / (settled + refunded)) as a percentage string. `null` when there is no settled or refunded history.
@@ -450,7 +450,7 @@ components:
           description: Network success rate over the past 30 days (null if no terminal orders).
     MarketsWindowedMedian:
       type: object
-      description: Median delivery time in seconds across windows. Null when the raw Postgres driver is unavailable (e.g. SQLite in tests) or no data exists.
+      description: Median delivery time in seconds across windows. Null for a window when no data exists.
       properties:
         24h:
           type: integer
@@ -468,31 +468,31 @@ components:
       type: object
       description: Network-wide stats block included in the markets response.
       properties:
-        settled_volume_usd:
+        settledVolumeUsd:
           allOf:
             - $ref: '#/components/schemas/MarketsWindowedVolume'
           description: USD volume of settled orders across windows.
-        settled_txns:
+        settledTxns:
           allOf:
             - $ref: '#/components/schemas/MarketsWindowedCount'
           description: Count of settled transactions across windows.
-        network_success_pct:
+        networkSuccessPercent:
           allOf:
             - $ref: '#/components/schemas/MarketsWindowedSuccess'
           description: Network-wide success rate (settled / (settled + refunded)) across windows.
-        median_delivery_secs:
+        medianDeliverySecs:
           allOf:
             - $ref: '#/components/schemas/MarketsWindowedMedian'
           description: Median order delivery time in seconds across windows.
-        active_providers:
+        activeProviders:
           allOf:
             - $ref: '#/components/schemas/MarketsWindowedCount'
           description: Count of distinct providers with at least one settled order across windows.
-        active_senders:
+        activeSenders:
           allOf:
             - $ref: '#/components/schemas/MarketsWindowedCount'
           description: Count of distinct senders with at least one settled order across windows.
-        live_liquidity_usd:
+        liveLiquidityUsd:
           type: string
           description: Total available USD-denominated liquidity across all book rows.
         corridors:
@@ -508,7 +508,7 @@ components:
       type: object
       description: Public markets orderbook and network-wide aggregates.
       properties:
-        as_of:
+        asOf:
           type: string
           format: date-time
           description: Timestamp when the response was generated (ISO 8601 UTC).
@@ -1910,7 +1910,7 @@ paths:
         plus network-wide aggregate statistics.
 
         **Public endpoint** — no authentication required, CORS open.
-        Responses are served from a ~10 s Redis cache. Requests are per-IP rate limited.
+        Responses are cached for ~10 s. Requests are per-IP rate limited.
 
         Provider balances and success rates are intentionally public to support integrator tooling and the Paycrest Markets dashboard.
       servers:

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -304,6 +304,22 @@ components:
       properties:
         reason:
           type: string
+    MarketPosition:
+      type: object
+      description: |
+        Provider's rate standing versus the best public peer in the same corridor.
+        Omitted when no qualifying public offers exist or the provider has no effective rate for the corridor (backward compatible).
+      properties:
+        bestPublicRate:
+          type: string
+          description: Best rate among enabled non-testnet public peers for this side (highest effective sell rate; lowest effective buy rate).
+        yourEffectiveRate:
+          type: string
+          description: The provider's own effective rate for this corridor and side.
+        deltaVsBest:
+          type: string
+          description: |
+            `yourEffectiveRate − bestPublicRate`. For **sell** a positive delta means you offer a higher rate than the best peer (more competitive). For **buy** a negative delta means you offer a lower rate than the best peer (more competitive).
     MarketRateSide:
       type: object
       description: Tolerance band for one side (buy or sell) of the market rate.
@@ -317,6 +333,10 @@ components:
         maximumRate:
           type: string
           description: Maximum allowed rate for this side.
+        position:
+          allOf:
+            - $ref: '#/components/schemas/MarketPosition'
+          description: Rate benchmark vs. best public peer. Omitted when no public benchmark exists (backward compatible).
     MarketRateResponse:
       type: object
       description: Market rate bounds split by side. Either or both of `buy` and `sell` may be present depending on corridor configuration.
@@ -325,6 +345,180 @@ components:
           $ref: '#/components/schemas/MarketRateSide'
         sell:
           $ref: '#/components/schemas/MarketRateSide'
+    MarketOffer:
+      type: object
+      description: |
+        One provider quote row in the public markets orderbook (one row per provider × side × token × fiat × network).
+        All funded, available providers appear regardless of visibility setting—only `is_available`, funded, enabled, and non-testnet gating applies.
+      properties:
+        provider_id:
+          type: string
+          description: Provider identifier.
+        side:
+          type: string
+          enum: [sell, buy]
+          description: '`sell` = offramp (crypto → fiat); `buy` = onramp (fiat → crypto).'
+        token:
+          type: string
+          description: Token symbol (e.g. `USDT`, `USDC`).
+        fiat:
+          type: string
+          description: Fiat currency code (e.g. `NGN`, `KES`).
+        network:
+          type: string
+          description: Network identifier (e.g. `base`, `ethereum`).
+        rate:
+          type: string
+          description: Provider's effective exchange rate for this row (fiat per crypto for sell; crypto per fiat for buy).
+        rate_type:
+          type: string
+          enum: [fixed, floating]
+          description: Whether the rate is fixed or floating.
+        min:
+          type: string
+          description: Minimum order amount accepted by this provider for this corridor.
+        max:
+          type: string
+          description: Maximum order amount accepted by this provider for this corridor.
+        balance:
+          type: string
+          description: |
+            Provider's available liquidity for this side. For **sell** this is in fiat (`balance_ccy` = fiat code);
+            for **buy** this is in token (`balance_ccy` = token symbol).
+            The balance is the shared pool repeated across a provider's networks for the same fiat/token—
+            de-duplicate by `provider_id + fiat` (sell) or `provider_id + token` (buy) when summing depth.
+        balance_ccy:
+          type: string
+          description: Currency of `balance` — fiat code for sell rows, token symbol for buy rows.
+        balance_usd:
+          type: string
+          description: Balance normalised to USD.
+        settled:
+          type: integer
+          description: Total number of settled orders for this provider in this corridor.
+        success_pct:
+          type: string
+          nullable: true
+          description: Provider's success rate (settled / (settled + refunded)) as a percentage string. `null` when there is no settled or refunded history.
+    MarketsWindowedVolume:
+      type: object
+      description: A USD/amount metric broken down across time windows.
+      properties:
+        24h:
+          type: string
+          description: Value over the past 24 hours.
+        7d:
+          type: string
+          description: Value over the past 7 days.
+        30d:
+          type: string
+          description: Value over the past 30 days.
+        all:
+          type: string
+          description: All-time value.
+    MarketsWindowedCount:
+      type: object
+      description: An integer count metric broken down across time windows.
+      properties:
+        24h:
+          type: integer
+          description: Count over the past 24 hours.
+        7d:
+          type: integer
+          description: Count over the past 7 days.
+        30d:
+          type: integer
+          description: Count over the past 30 days.
+        all:
+          type: integer
+          description: All-time count.
+    MarketsWindowedSuccess:
+      type: object
+      description: Success-percentage metric across 24h/7d/30d windows. Null for a window when no terminal orders exist in that window.
+      properties:
+        24h:
+          type: string
+          nullable: true
+          description: Network success rate over the past 24 hours (null if no terminal orders).
+        7d:
+          type: string
+          nullable: true
+          description: Network success rate over the past 7 days (null if no terminal orders).
+        30d:
+          type: string
+          nullable: true
+          description: Network success rate over the past 30 days (null if no terminal orders).
+    MarketsWindowedMedian:
+      type: object
+      description: Median delivery time in seconds across windows. Null when the raw Postgres driver is unavailable (e.g. SQLite in tests) or no data exists.
+      properties:
+        24h:
+          type: integer
+          nullable: true
+          description: Median delivery seconds over the past 24 hours.
+        7d:
+          type: integer
+          nullable: true
+          description: Median delivery seconds over the past 7 days.
+        30d:
+          type: integer
+          nullable: true
+          description: Median delivery seconds over the past 30 days.
+    MarketsAggregates:
+      type: object
+      description: Network-wide stats block included in the markets response.
+      properties:
+        settled_volume_usd:
+          allOf:
+            - $ref: '#/components/schemas/MarketsWindowedVolume'
+          description: USD volume of settled orders across windows.
+        settled_txns:
+          allOf:
+            - $ref: '#/components/schemas/MarketsWindowedCount'
+          description: Count of settled transactions across windows.
+        network_success_pct:
+          allOf:
+            - $ref: '#/components/schemas/MarketsWindowedSuccess'
+          description: Network-wide success rate (settled / (settled + refunded)) across windows.
+        median_delivery_secs:
+          allOf:
+            - $ref: '#/components/schemas/MarketsWindowedMedian'
+          description: Median order delivery time in seconds across windows.
+        active_providers:
+          allOf:
+            - $ref: '#/components/schemas/MarketsWindowedCount'
+          description: Count of distinct providers with at least one settled order across windows.
+        active_senders:
+          allOf:
+            - $ref: '#/components/schemas/MarketsWindowedCount'
+          description: Count of distinct senders with at least one settled order across windows.
+        live_liquidity_usd:
+          type: string
+          description: Total available USD-denominated liquidity across all book rows.
+        corridors:
+          type: integer
+          description: Number of distinct token/fiat pairs currently in the book.
+        tokens:
+          type: integer
+          description: Number of distinct tokens currently in the book.
+        networks:
+          type: integer
+          description: Number of distinct networks currently in the book.
+    MarketsResponse:
+      type: object
+      description: Public markets orderbook and network-wide aggregates.
+      properties:
+        as_of:
+          type: string
+          format: date-time
+          description: Timestamp when the response was generated (ISO 8601 UTC).
+        aggregates:
+          $ref: '#/components/schemas/MarketsAggregates'
+        book:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketOffer'
+          description: Array of provider quote rows forming the live orderbook.
     V2RateQuoteSide:
       type: object
       description: Quote details for one side from the public v2 rates endpoint.
@@ -1705,6 +1899,36 @@ paths:
                             type: object
         '400':
           description: Bad request
+
+  /markets:
+    get:
+      tags:
+        - General
+      summary: Get markets orderbook
+      description: |
+        Returns the live protocol orderbook (all funded, available provider quotes across corridors × tokens × networks)
+        plus network-wide aggregate statistics.
+
+        **Public endpoint** — no authentication required, CORS open.
+        Responses are served from a ~10 s Redis cache. Requests are per-IP rate limited.
+
+        Provider balances and success rates are intentionally public to support integrator tooling and the Paycrest Markets dashboard.
+      servers:
+        - url: https://api.paycrest.io/v2
+      responses:
+        '200':
+          description: Markets orderbook and aggregates
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/MarketsResponse'
+        '429':
+          description: Too many requests (per-IP rate limit exceeded)
 
   # ─── V2 Sender Endpoints ─────────────────────────────────────────────────────
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -9,6 +9,27 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ## Q2 2026
 
+### Public markets orderbook & provider rate position (June 2026)
+
+**New:** `GET /v2/markets` — unauthenticated public endpoint returning the live protocol orderbook and network-wide aggregate statistics. No API key required; CORS open; ~10 s cache; per-IP rate limited.
+
+- **`data.book`** — array of provider quote rows (one per provider × side × token × fiat × network), including `rate`, `rate_type`, `min`, `max`, `balance`, `balance_usd`, `settled`, and `success_pct`.
+- **`data.aggregates`** — network-wide stats: settled volume/txns (24h/7d/30d/all-time), success rate, median delivery seconds, active providers/senders, live liquidity USD, and corridor/token/network counts.
+
+**Updated:** `GET /v1/provider/rates/{token}/{fiat}` and `GET /v2/provider/rates/{token}/{fiat}` — each side (`buy`, `sell`) now carries an optional **`position`** object so providers can benchmark their effective rate against the best public peer in the same corridor:
+
+| Field | Description |
+|-------|-------------|
+| `bestPublicRate` | Best rate among enabled non-testnet public peers (highest for sell; lowest for buy) |
+| `yourEffectiveRate` | Your effective rate for this corridor |
+| `deltaVsBest` | `yourEffectiveRate − bestPublicRate` — positive means higher; for sell positive is more competitive, for buy negative is more competitive |
+
+`position` is omitted when no qualifying public offers exist or you have no effective rate configured (backward compatible).
+
+See [Get Markets](/api-reference/general/get-markets) and [Get Market Rate](/api-reference/provider/get-market-rate).
+
+---
+
 ### Webhook delivery logs & retry API (June 2026)
 
 Senders can now audit and replay webhook deliveries instead of re-triggering the order flow when an endpoint is briefly down.

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -13,7 +13,7 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 **New:** `GET /v2/markets` — unauthenticated public endpoint returning the live protocol orderbook and network-wide aggregate statistics. No API key required; CORS open; ~10 s cache; per-IP rate limited.
 
-- **`data.book`** — array of provider quote rows (one per provider × side × token × fiat × network), including `rate`, `rate_type`, `min`, `max`, `balance`, `balance_usd`, `settled`, and `success_pct`.
+- **`data.book`** — array of provider quote rows (one per provider × side × token × fiat × network), including `rate`, `rateType`, `min`, `max`, `balance`, `balanceUsd`, `settled`, and `successPercent`.
 - **`data.aggregates`** — network-wide stats: settled volume/txns (24h/7d/30d/all-time), success rate, median delivery seconds, active providers/senders, live liquidity USD, and corridor/token/network counts.
 
 **Updated:** `GET /v1/provider/rates/{token}/{fiat}` and `GET /v2/provider/rates/{token}/{fiat}` — each side (`buy`, `sell`) now carries an optional **`position`** object so providers can benchmark their effective rate against the best public peer in the same corridor:


### PR DESCRIPTION
## Description

Documents the two capabilities added in aggregator PR [paycrest/aggregator#826](https://github.com/paycrest/aggregator/pull/826):

1. **Public `GET /v2/markets`** — unauthenticated orderbook (`book[]`) + network-wide `aggregates` (settled volume/txns, success %, median delivery, active providers/senders, live liquidity, corridor/token/network counts). No auth, CORS open, ~10s cache, per-IP rate limited.
2. **Provider rate `position`** — `GET /provider/rates/{token}/{fiat}` (v1 + v2) now carries an optional per-side `position` object (`bestPublicRate`, `yourEffectiveRate`, `deltaVsBest`) benchmarking the provider against the best public peer. Backward compatible — omitted when no qualifying public offers exist or the provider has no effective rate.

## Changes

- **New** `api-reference/general/get-markets.mdx` — full endpoint page: response shape `{ as_of, aggregates, book }`, book field table (13 fields), aggregates field table, balance de-dup note, public-exposure note, example JSON, errors.
- **`openapi-v2.yaml`** — add `MarketPosition`, `MarketOffer`, `MarketsWindowedVolume/Count/Success/Median`, `MarketsAggregates`, `MarketsResponse`; extend `MarketRateSide` with optional `position`; add public `GET /markets` path (no `security`).
- **`openapi-v1.yaml`** — add `MarketPosition`; extend `MarketRateSide` with optional `position` (response parity with v2 provider route).
- **`api-reference/provider/get-market-rate.mdx`** — document the `position` object, `deltaVsBest` per-side semantics, omission rules, with/without examples.
- **`api-reference/provider/get-market-rate-v1.mdx`** — note `position` applies on v1 too, cross-linking the v2 page.
- **`docs.json`** — add `get-markets` to v2 → General group (after `get-token-rate`).
- **`resources/changelog.mdx`** — Q2 2026 entry.

## Verification

- Field names/types coordinated with aggregator `types/types.go` on the PR branch; decimals documented as strings per existing convention.
- `position` semantics verified against `attachRatePosition` / `BestEffectiveRate` (delta = yours − best; best = highest sell / lowest buy; excludes own quotes; all enabled non-testnet networks).
- `success_pct` / `network_success_pct` confirmed as 0–100 percentages; markets envelope confirmed wrapped in `{status, message, data}` with message `"OK"`.
- Both OpenAPI files parse cleanly; `$ref`s carrying descriptions use `allOf` wrappers (OpenAPI 3.0 compliant).

Closes paycrest/docs#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)