### PR TITLE
docs(code-standards): clarify SWIFT/BIC institution codes + historical exceptions

### DIFF
--- a/resources/code-standards.mdx
+++ b/resources/code-standards.mdx
@@ -50,6 +50,16 @@ For mobile payment providers, local banks without SWIFT codes, and other financi
 
 For KES **Till** and **Paybill** offramps, keep **`SAFAKEPC`** (or the same mobile institution you use for M-Pesa) and set **`destination.recipient.metadata.channel`** to **`Till`** or **`Paybill`** (and **`businessNumber`** for Paybill). See **[Sender API Integration — KES mobile money](/implementation-guides/sender-api-integration#kes-mobile-money-m-pesa-till-paybill)**.
 
+### Canonical Code vs. SWIFT/BIC
+
+The institution **code is the canonical Paycrest identifier** — it is what the API accepts, what is stored on orders, and the key every integration looks up. It is *derived* from SWIFT but is **not** the raw SWIFT/BIC. Where a bank's official SWIFT differs from its Paycrest code, the Paycrest code stays canonical and the SWIFT is only a reference alias — never used in its place.
+
+#### Examples:
+- **SBICNGLA** — Stanbic IBTC Bank. The official SWIFT is `SBICNGLX`; that is an alias and is **not** a valid institution code.
+- **PROVNGLA** — Providus Bank. The raw SWIFT-style `UMPLNGLA` is an alias, **not** the code.
+
+Always use the exact code returned by **[GET /institutions/{currency_code}](/api-reference/general/list-supported-institutions)**. Do not derive a code from an external SWIFT/BIC database — codes there can differ from the canonical Paycrest code and will be rejected.
+
 ## Code Format Rules
 
 ### Currency Codes

--- a/resources/code-standards.mdx
+++ b/resources/code-standards.mdx
@@ -39,14 +39,14 @@ For major international banks and domestic banks with SWIFT codes, Paycrest uses
 
 ### Custom Codes (Local Institutions)
 
-For mobile payment providers, local banks without SWIFT codes, and other financial institutions, Paycrest uses custom codes that follow a SWIFT-like format ending with **"PC"** (PayCrest).
+For mobile payment providers, local banks without SWIFT codes, and other financial institutions, Paycrest uses custom 8-character codes built as: **4 letters from the institution's name** (where possible) + the **2-letter ISO country code** + **`PC`** (PayCrest).
 
 #### Examples:
-- **KUDANGPC** - Kuda Bank (Nigeria)
-- **OPAYNGPC** - OPay (Nigeria)
-- **MONINGPC** - Moniepoint (Nigeria)
-- **SAFAKEPC** - Safaricom M-Pesa (Kenya)
-- **AIRTKEPC** - Airtel Money (Kenya)
+- **KUDANGPC** - Kuda (Nigeria): `KUDA` + `NG` + `PC`
+- **OPAYNGPC** - OPay (Nigeria): `OPAY` + `NG` + `PC`
+- **MONINGPC** - Moniepoint (Nigeria): `MONI` + `NG` + `PC`
+- **SAFAKEPC** - Safaricom M-Pesa (Kenya): `SAFA` + `KE` + `PC`
+- **AIRTKEPC** - Airtel Money (Kenya): `AIRT` + `KE` + `PC`
 
 For KES **Till** and **Paybill** offramps, keep **`SAFAKEPC`** (or the same mobile institution you use for M-Pesa) and set **`destination.recipient.metadata.channel`** to **`Till`** or **`Paybill`** (and **`businessNumber`** for Paybill). See **[Sender API Integration — KES mobile money](/implementation-guides/sender-api-integration#kes-mobile-money-m-pesa-till-paybill)**.
 
@@ -71,8 +71,8 @@ Because of these exceptions, **always use the exact code returned by [GET /insti
 
 ### Institution Codes
 - **Format**: 8 characters
-- **International Banks**: First 7 characters of SWIFT code
-- **Local Institutions**: Custom code ending with "PC"
+- **Banks with a SWIFT/BIC**: the bank's 8-character SWIFT/BIC code
+- **Local Institutions (no SWIFT)**: 4 letters from the name + 2-letter ISO country code + `PC`
 - **Case**: Always uppercase
 - **Examples**: `GTBINGLA`, `KUDANGPC`
 

--- a/resources/code-standards.mdx
+++ b/resources/code-standards.mdx
@@ -50,15 +50,16 @@ For mobile payment providers, local banks without SWIFT codes, and other financi
 
 For KES **Till** and **Paybill** offramps, keep **`SAFAKEPC`** (or the same mobile institution you use for M-Pesa) and set **`destination.recipient.metadata.channel`** to **`Till`** or **`Paybill`** (and **`businessNumber`** for Paybill). See **[Sender API Integration — KES mobile money](/implementation-guides/sender-api-integration#kes-mobile-money-m-pesa-till-paybill)**.
 
-### Canonical Code vs. SWIFT/BIC
+### Codes and SWIFT/BIC
 
-The institution **code is the canonical Paycrest identifier** — it is what the API accepts, what is stored on orders, and the key every integration looks up. It is *derived* from SWIFT but is **not** the raw SWIFT/BIC. Where a bank's official SWIFT differs from its Paycrest code, the Paycrest code stays canonical and the SWIFT is only a reference alias — never used in its place.
+For an institution that has a SWIFT/BIC, the Paycrest code **is** that 8-character SWIFT/BIC — including banks whose code reflects a former name. For example **`ZEIBNGLA`** (Zenith, from "Zenith International Bank"), **`NAMENGLA`** (Sterling, from the former NAL Bank), and **`KDHLNGLA`** (FBNQuest, from Kakawa Discount House) are all the banks' real BICs. Institutions without a SWIFT — mobile money, microfinance banks, and other fintechs — use a custom code ending in **`PC`**.
 
-#### Examples:
-- **SBICNGLA** — Stanbic IBTC Bank. The official SWIFT is `SBICNGLX`; that is an alias and is **not** a valid institution code.
-- **PROVNGLA** — Providus Bank. The raw SWIFT-style `UMPLNGLA` is an alias, **not** the code.
+A few historical codes predate this convention and differ from the bank's current SWIFT:
 
-Always use the exact code returned by **[GET /institutions/{currency_code}](/api-reference/general/list-supported-institutions)**. Do not derive a code from an external SWIFT/BIC database — codes there can differ from the canonical Paycrest code and will be rejected.
+- **`SBICNGLA`** — Stanbic IBTC Bank (official SWIFT `SBICNGLX`)
+- **`PROVNGLA`** — Providus Bank (official SWIFT `UMPLNGLA`)
+
+Because of these exceptions, **always use the exact code returned by [GET /institutions/{currency_code}](/api-reference/general/list-supported-institutions)** — it is the single source of truth. Do not assume a code equals the bank's public SWIFT, and do not derive codes from an external SWIFT/BIC directory.
 
 ## Code Format Rules
 

--- a/resources/code-standards.mdx
+++ b/resources/code-standards.mdx
@@ -25,9 +25,9 @@ Paycrest uses **ISO 4217** standard currency codes, which are the internationall
 
 Paycrest uses a hybrid approach for institution codes to accommodate both international banks and local financial institutions.
 
-### SWIFT Codes (International Banks)
+### SWIFT Codes (Banks)
 
-For major international banks and domestic banks with SWIFT codes, Paycrest uses the first **7 characters** of the SWIFT/BIC code.
+For a bank that has a SWIFT/BIC, the Paycrest code **is** the bank's 8-character SWIFT/BIC code.
 
 #### Examples:
 - **GTBINGLA** - Guaranty Trust Bank (Nigeria)
@@ -36,6 +36,12 @@ For major international banks and domestic banks with SWIFT codes, Paycrest uses
 - **SCBLNGLA** - Standard Chartered Bank Nigeria
 - **KCBLKENX** - Kenya Commercial Bank
 - **EQBLKENA** - Equity Bank Kenya
+
+Some codes reflect a bank's **former name** but are still its real BIC — e.g. `ZEIBNGLA` (Zenith, from "Zenith International Bank"), `NAMENGLA` (Sterling, from the former NAL Bank), and `KDHLNGLA` (FBNQuest, from Kakawa Discount House).
+
+A few historical codes differ from the bank's current SWIFT — use the Paycrest code, not the SWIFT you may find elsewhere:
+- **`SBICNGLA`** — Stanbic IBTC Bank (SWIFT `SBICNGLX`)
+- **`PROVNGLA`** — Providus Bank (SWIFT `UMPLNGLA`)
 
 ### Custom Codes (Local Institutions)
 
@@ -49,17 +55,6 @@ For mobile payment providers, local banks without SWIFT codes, and other financi
 - **AIRTKEPC** - Airtel Money (Kenya): `AIRT` + `KE` + `PC`
 
 For KES **Till** and **Paybill** offramps, keep **`SAFAKEPC`** (or the same mobile institution you use for M-Pesa) and set **`destination.recipient.metadata.channel`** to **`Till`** or **`Paybill`** (and **`businessNumber`** for Paybill). See **[Sender API Integration — KES mobile money](/implementation-guides/sender-api-integration#kes-mobile-money-m-pesa-till-paybill)**.
-
-### Codes and SWIFT/BIC
-
-For an institution that has a SWIFT/BIC, the Paycrest code **is** that 8-character SWIFT/BIC — including banks whose code reflects a former name. For example **`ZEIBNGLA`** (Zenith, from "Zenith International Bank"), **`NAMENGLA`** (Sterling, from the former NAL Bank), and **`KDHLNGLA`** (FBNQuest, from Kakawa Discount House) are all the banks' real BICs. Institutions without a SWIFT — mobile money, microfinance banks, and other fintechs — use a custom code ending in **`PC`**.
-
-A few historical codes predate this convention and differ from the bank's current SWIFT:
-
-- **`SBICNGLA`** — Stanbic IBTC Bank (official SWIFT `SBICNGLX`)
-- **`PROVNGLA`** — Providus Bank (official SWIFT `UMPLNGLA`)
-
-Because of these exceptions, **always use the exact code returned by [GET /institutions/{currency_code}](/api-reference/general/list-supported-institutions)** — it is the single source of truth. Do not assume a code equals the bank's public SWIFT, and do not derive codes from an external SWIFT/BIC directory.
 
 ## Code Format Rules
 


### PR DESCRIPTION
Part of paycrest/institutions#1.

Clarifies the institution-codes standard:

- For institutions **with** a SWIFT/BIC, the Paycrest code **is** that 8-char SWIFT — including banks whose code reflects a former name (Zenith `ZEIBNGLA`, Sterling `NAMENGLA`, FBNQuest `KDHLNGLA` are all real legacy BICs).
- Institutions **without** a SWIFT (mobile money, MFBs, fintechs) use a custom `*PC` code.
- A couple of historical codes differ from the bank's current SWIFT — Stanbic (`SBICNGLA`, SWIFT `SBICNGLX`) and Providus (`PROVNGLA`, SWIFT `UMPLNGLA`) — so `GET /institutions/{currency}` is the authoritative source.

Note: an earlier revision of this PR had the framing backwards (it described the real SWIFTs `UMPLNGLA`/`SBICNGLX` as mere "aliases, not real codes"). Corrected — `UMPLNGLA`/`SBICNGLX` are the banks' actual BICs; `PROVNGLA`/`SBICNGLA` are the historical exceptions. This does not pre-announce the separate SWIFT-first migration.