### PR TITLE
docs(markets): document GET /v2/markets query filters

### DIFF
--- a/api-reference/general/get-markets.mdx
+++ b/api-reference/general/get-markets.mdx
@@ -9,13 +9,26 @@ Returns the live protocol **orderbook** (every funded, available provider quote 
   **Public endpoint** — no API key or HMAC signature required. CORS is open. Responses are cached for ~10 s and are per-IP rate limited.
 </Note>
 
+## Query parameters
+
+Optional filters narrow `data.book` only. **`data.aggregates` always remain network-wide** (same values whether or not you filter the book).
+
+| Param | Form | Description |
+|-------|------|-------------|
+| `side` | single | `buy` or `sell`; omit for both. Invalid values return **400** |
+| `fiat` | comma-separated | e.g. `NGN,KES` (case-sensitive codes as stored) |
+| `token` | comma-separated | e.g. `USDC,USDT` |
+| `network` | comma-separated | e.g. `base,polygon` |
+
+Empty or omitted params apply no filter on that dimension.
+
 ## Response shape (`data`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `asOf` | string (ISO 8601) | Timestamp when the response was generated |
-| `aggregates` | object | Network-wide aggregate statistics (see below) |
-| `book` | array | Provider quote rows forming the live orderbook |
+| `aggregates` | object | Network-wide aggregate statistics (see below) — not affected by query filters |
+| `book` | array | Provider quote rows forming the live orderbook (optionally filtered) |
 
 ## Book row fields
 
@@ -123,9 +136,18 @@ GET https://api.paycrest.io/v2/markets
 }
 ```
 
+### Filtered example
+
+Sell-side USDC offers on Base for NGN or KES. Aggregates in the response are still the full network-wide KPIs.
+
+```bash
+GET https://api.paycrest.io/v2/markets?side=sell&fiat=NGN,KES&token=USDC&network=base
+```
+
 ## Errors
 
 | HTTP | Cause |
 |------|-------|
+| **400** | Invalid `side` (expected `buy` or `sell`) |
 | **429** | Per-IP rate limit exceeded |
 | **500** | Internal error |

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1912,9 +1912,42 @@ paths:
         **Public endpoint** — no authentication required, CORS open.
         Responses are cached for ~10 s. Requests are per-IP rate limited.
 
+        Optional query filters (`side`, `fiat`, `token`, `network`) apply only to `data.book`.
+        `data.aggregates` always remain network-wide (unfiltered).
+
         Provider balances and success rates are intentionally public to support integrator tooling and the Paycrest Markets dashboard.
       servers:
         - url: https://api.paycrest.io/v2
+      parameters:
+        - in: query
+          name: side
+          schema:
+            type: string
+            enum: [buy, sell]
+          description: |
+            Return only buy or sell book rows. Omit for both sides.
+            Invalid values return `400`.
+        - in: query
+          name: fiat
+          schema:
+            type: string
+          description: |
+            Comma-separated fiat currency codes (e.g. `NGN,KES`). Case-sensitive as stored.
+            Filters `data.book` only; omit for all fiats.
+        - in: query
+          name: token
+          schema:
+            type: string
+          description: |
+            Comma-separated token symbols (e.g. `USDC,USDT`).
+            Filters `data.book` only; omit for all tokens.
+        - in: query
+          name: network
+          schema:
+            type: string
+          description: |
+            Comma-separated network identifiers (e.g. `base,polygon`).
+            Filters `data.book` only; omit for all networks.
       responses:
         '200':
           description: Markets orderbook and aggregates
@@ -1927,6 +1960,12 @@ paths:
                     properties:
                       data:
                         $ref: '#/components/schemas/MarketsResponse'
+        '400':
+          description: Invalid `side` (expected `buy` or `sell`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '429':
           description: Too many requests (per-IP rate limit exceeded)
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -7,6 +7,25 @@ This page tracks significant changes to the Paycrest API and protocol. For full 
 
 ---
 
+## Q3 2026
+
+### Markets orderbook query filters (July 2026)
+
+**Updated:** `GET /v2/markets` accepts optional query filters to narrow the returned orderbook:
+
+| Param | Form | Behavior |
+|-------|------|----------|
+| `side` | single | `buy` or `sell`; omit for both. Invalid values return **400** |
+| `fiat` | comma-separated | e.g. `NGN,KES` |
+| `token` | comma-separated | e.g. `USDC,USDT` |
+| `network` | comma-separated | e.g. `base,polygon` |
+
+Filters apply only to **`data.book`**. **`data.aggregates` remain network-wide** (unfiltered), matching dashboard behavior (global KPIs, filtered table).
+
+See [Get Markets](/api-reference/general/get-markets).
+
+---
+
 ## Q2 2026
 
 ### Public markets orderbook & provider rate position (June 2026)


### PR DESCRIPTION
### Description

Documents optional `side`, `fiat`, `token`, and `network` query filters on `GET /v2/markets`. Filters narrow `data.book` only; `data.aggregates` remain network-wide.

Updates OpenAPI (`openapi-v2.yaml`), the Get Markets API page, and the changelog.

### Testing

- Review OpenAPI params and MDX examples against aggregator PR behavior
- Confirm Mintlify preview renders Query parameters + filtered example

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
